### PR TITLE
Directed (single-phase) embed mode + longitudinal study QSF

### DIFF
--- a/QUALTRICS_INTEGRATION.md
+++ b/QUALTRICS_INTEGRATION.md
@@ -18,10 +18,20 @@ The app reads two query parameters on load:
 |----------------|----------|-------------------------------------------------------------------------|
 | `sid`          | yes      | Unique session key minted by Qualtrics. Stamped onto every payload and onto local records. |
 | `parentOrigin` | optional | Explicit target origin for `postMessage`. If omitted, messages are posted with target `*`. Recommended for production. |
+| `phase`        | optional | `full` (default) runs the normal standalone game (intro + all scenarios). `tutorial` runs only the interactive tutorial. `scenario` runs exactly one scenario (see `scenario`). The `tutorial`/`scenario` values enable **directed mode** for a longitudinal split flow — see §7. |
+| `scenario`     | with `phase=scenario` | Which scenario to run: an id (`s4` = Arterial Line, `s2` = Central Line, `s3` = Chest Tube) or a 0-based index. |
 
 If `sid` is absent **and** the app is not running inside an iframe, it behaves
 exactly as the standalone/testing build: nothing is transmitted, localStorage
-and the Export button work as before.
+and the Export button work as before. `phase` defaults to `full`, so existing
+single-iframe embeds keep working unchanged.
+
+> **Stony Brook note:** for `stonybrookmedicine.edu` accounts you can pin the
+> target with `&parentOrigin=https://stonybrookmedicine.qualtrics.com` (or your
+> account's actual `*.qualtrics.com` host shown in the editor address bar). It's
+> optional — security relies on the listener validating the *sender* origin
+> (`https://christiantreat.github.io`), so leaving it off (target `*`) is fine
+> and more portable across datacenters.
 
 **Example embed URL** (what the iframe `src` should be):
 
@@ -347,4 +357,75 @@ In the iframe's devtools console you can confirm the parsed params:
 
 ```js
 new URLSearchParams(location.search).get('sid'); // "TEST123"
+```
+
+---
+
+## 7. Longitudinal study flow (directed mode)
+
+For a study you usually want survey questions **between** game phases:
+
+> Consent/intake → **Tutorial** → questions → **Scenario 1** → questions →
+> **Scenario 2** → questions → **Scenario 3** → questions → post-intervention → end
+
+A single all-in-one iframe can't interleave Qualtrics questions, so each phase
+runs on its **own survey page** as a separate iframe pointed at one phase via the
+`phase`/`scenario` URL params. Every page carries the **same `sid`**, so all the
+data lands in **one response row** — longitudinal and panel-linkable.
+
+### How directed mode behaves
+- The app skips the cinematic intro and menus and runs only the requested phase.
+- When that phase finishes, the app emits **`session_complete`** carrying *only
+  that phase's* fields plus that page's own compact event log. Because each page
+  reports only its own `cq_mN_*` fields, **values never collide across pages.**
+- The listener treats `session_complete` as the **advance signal** and calls
+  `clickNextButton()` to move the survey to the next page (the questions).
+- `mission_complete` still fires on submit (before the participant clicks
+  *Continue*), so partial data is captured even if they abandon the page.
+
+### Additional embedded-data fields in directed mode
+On top of the per-mission `cq_mN_*` fields (§3), directed mode emits:
+
+| Field              | When            | Meaning |
+|--------------------|-----------------|---------|
+| `cq_tut_completed` | tutorial page   | 1 if the tutorial was completed, 0 if skipped |
+| `cq_tut_time`      | tutorial page   | seconds spent on the tutorial |
+| `cq_app_version`   | every phase     | app version |
+| `cq_mode`          | scenario pages  | `training` |
+| `cq_log_tutorial`  | tutorial page   | event log for the tutorial page |
+| `cq_log_m1`        | scenario s4     | event log for the Arterial Line page |
+| `cq_log_m2`        | scenario s2     | event log for the Central Line page |
+| `cq_log_m3`        | scenario s3     | event log for the Chest Tube page |
+
+(The cross-mission session aggregates — `cq_total_score`, `cq_avg_*`,
+`cq_missions_done` — are **only** produced by `full` mode. In the split flow,
+compute those in Qualtrics/analysis from the per-scenario `cq_mN_*` fields.)
+
+### Ready-to-import study survey
+**`cabinet-quest-study.qsf`** implements the whole flow above:
+
+- Survey Flow pre-declares all 60 fields (`sid`, 51 × `cq_mN_*`, `cq_tut_*`,
+  `cq_app_version`, `cq_mode`, and the four `cq_log_*`).
+- 10 blocks (one page each): Consent/Intake → Tutorial → Tutorial Qs →
+  Scenario 1 → Qs → Scenario 2 → Qs → Scenario 3 → Qs → Post-Intervention.
+- Each game page injects its iframe with the right `phase`/`scenario`, runs the
+  listener, writes that page's log to its `cq_log_*` field, **hides Next until
+  the phase completes** (so participants can't skip the game), and auto-advances
+  on `session_complete`.
+- The Consent and Post-Intervention blocks and the per-phase question blocks are
+  **placeholders** — replace them with your IRB-approved items. The placeholder
+  questions are simple 1–5 items (`q_tutorial`, `q_s1`, `q_s2`, `q_s3`).
+
+Import via **Projects → Create project → Survey → Import a QSF file**, pick
+`cabinet-quest-study.qsf`, then publish and preview.
+
+> The simpler single-page demo (`cabinet-quest-demo.qsf`, §4–5) still exists for
+> running the whole game on one page with all metrics on one screen.
+
+### Per-page embed URLs (what each iframe loads)
+```
+Tutorial:    https://christiantreat.github.io/CabinetQuest/?sid=${e://Field/sid}&phase=tutorial
+Scenario 1:  https://christiantreat.github.io/CabinetQuest/?sid=${e://Field/sid}&phase=scenario&scenario=s4
+Scenario 2:  https://christiantreat.github.io/CabinetQuest/?sid=${e://Field/sid}&phase=scenario&scenario=s2
+Scenario 3:  https://christiantreat.github.io/CabinetQuest/?sid=${e://Field/sid}&phase=scenario&scenario=s3
 ```

--- a/cabinet-quest-study.qsf
+++ b/cabinet-quest-study.qsf
@@ -1,0 +1,1458 @@
+{
+  "SurveyEntry": {
+    "SurveyID": "SV_CabinetQuestStudy01",
+    "SurveyName": "Cabinet Quest Study",
+    "SurveyDescription": null,
+    "SurveyOwnerID": "UR_CabinetQuestOwner",
+    "SurveyBrandID": "cabinetquest",
+    "DivisionID": null,
+    "SurveyLanguage": "EN",
+    "SurveyActiveResponseSet": "RS_default",
+    "SurveyStatus": "Inactive",
+    "SurveyStartDate": "0000-00-00 00:00:00",
+    "SurveyExpirationDate": "0000-00-00 00:00:00",
+    "SurveyCreationDate": "2026-06-09 14:10:00",
+    "CreatorID": "UR_CabinetQuestOwner",
+    "LastModified": "2026-06-09 14:10:00",
+    "LastAccessed": "0000-00-00 00:00:00",
+    "LastActivated": "0000-00-00 00:00:00",
+    "Deleted": null
+  },
+  "SurveyElements": [
+    {
+      "SurveyID": "SV_CabinetQuestStudy01",
+      "Element": "FL",
+      "PrimaryAttribute": "Survey Flow",
+      "SecondaryAttribute": null,
+      "TertiaryAttribute": null,
+      "Payload": {
+        "Flow": [
+          {
+            "Type": "EmbeddedData",
+            "FlowID": "FL_2",
+            "EmbeddedData": [
+              {
+                "Description": "sid",
+                "Type": "Custom",
+                "Field": "sid",
+                "VariableType": "String",
+                "DataVisibility": {
+                  "Hidden": false,
+                  "Private": false
+                },
+                "AnalyzeText": false,
+                "Value": "${rand://int/100000:999999}"
+              },
+              {
+                "Description": "cq_m1_scenario",
+                "Type": "Custom",
+                "Field": "cq_m1_scenario",
+                "VariableType": "String",
+                "DataVisibility": {
+                  "Hidden": false,
+                  "Private": false
+                },
+                "AnalyzeText": false,
+                "Value": ""
+              },
+              {
+                "Description": "cq_m1_time",
+                "Type": "Custom",
+                "Field": "cq_m1_time",
+                "VariableType": "String",
+                "DataVisibility": {
+                  "Hidden": false,
+                  "Private": false
+                },
+                "AnalyzeText": false,
+                "Value": ""
+              },
+              {
+                "Description": "cq_m1_score",
+                "Type": "Custom",
+                "Field": "cq_m1_score",
+                "VariableType": "String",
+                "DataVisibility": {
+                  "Hidden": false,
+                  "Private": false
+                },
+                "AnalyzeText": false,
+                "Value": ""
+              },
+              {
+                "Description": "cq_m1_stars",
+                "Type": "Custom",
+                "Field": "cq_m1_stars",
+                "VariableType": "String",
+                "DataVisibility": {
+                  "Hidden": false,
+                  "Private": false
+                },
+                "AnalyzeText": false,
+                "Value": ""
+              },
+              {
+                "Description": "cq_m1_ess_found",
+                "Type": "Custom",
+                "Field": "cq_m1_ess_found",
+                "VariableType": "String",
+                "DataVisibility": {
+                  "Hidden": false,
+                  "Private": false
+                },
+                "AnalyzeText": false,
+                "Value": ""
+              },
+              {
+                "Description": "cq_m1_ess_total",
+                "Type": "Custom",
+                "Field": "cq_m1_ess_total",
+                "VariableType": "String",
+                "DataVisibility": {
+                  "Hidden": false,
+                  "Private": false
+                },
+                "AnalyzeText": false,
+                "Value": ""
+              },
+              {
+                "Description": "cq_m1_opt_found",
+                "Type": "Custom",
+                "Field": "cq_m1_opt_found",
+                "VariableType": "String",
+                "DataVisibility": {
+                  "Hidden": false,
+                  "Private": false
+                },
+                "AnalyzeText": false,
+                "Value": ""
+              },
+              {
+                "Description": "cq_m1_opt_total",
+                "Type": "Custom",
+                "Field": "cq_m1_opt_total",
+                "VariableType": "String",
+                "DataVisibility": {
+                  "Hidden": false,
+                  "Private": false
+                },
+                "AnalyzeText": false,
+                "Value": ""
+              },
+              {
+                "Description": "cq_m1_extra",
+                "Type": "Custom",
+                "Field": "cq_m1_extra",
+                "VariableType": "String",
+                "DataVisibility": {
+                  "Hidden": false,
+                  "Private": false
+                },
+                "AnalyzeText": false,
+                "Value": ""
+              },
+              {
+                "Description": "cq_m1_missed_ess",
+                "Type": "Custom",
+                "Field": "cq_m1_missed_ess",
+                "VariableType": "String",
+                "DataVisibility": {
+                  "Hidden": false,
+                  "Private": false
+                },
+                "AnalyzeText": false,
+                "Value": ""
+              },
+              {
+                "Description": "cq_m1_correct",
+                "Type": "Custom",
+                "Field": "cq_m1_correct",
+                "VariableType": "String",
+                "DataVisibility": {
+                  "Hidden": false,
+                  "Private": false
+                },
+                "AnalyzeText": false,
+                "Value": ""
+              },
+              {
+                "Description": "cq_m1_incorrect",
+                "Type": "Custom",
+                "Field": "cq_m1_incorrect",
+                "VariableType": "String",
+                "DataVisibility": {
+                  "Hidden": false,
+                  "Private": false
+                },
+                "AnalyzeText": false,
+                "Value": ""
+              },
+              {
+                "Description": "cq_m1_accuracy",
+                "Type": "Custom",
+                "Field": "cq_m1_accuracy",
+                "VariableType": "String",
+                "DataVisibility": {
+                  "Hidden": false,
+                  "Private": false
+                },
+                "AnalyzeText": false,
+                "Value": ""
+              },
+              {
+                "Description": "cq_m1_drawers_opened",
+                "Type": "Custom",
+                "Field": "cq_m1_drawers_opened",
+                "VariableType": "String",
+                "DataVisibility": {
+                  "Hidden": false,
+                  "Private": false
+                },
+                "AnalyzeText": false,
+                "Value": ""
+              },
+              {
+                "Description": "cq_m1_distinct_drawers",
+                "Type": "Custom",
+                "Field": "cq_m1_distinct_drawers",
+                "VariableType": "String",
+                "DataVisibility": {
+                  "Hidden": false,
+                  "Private": false
+                },
+                "AnalyzeText": false,
+                "Value": ""
+              },
+              {
+                "Description": "cq_m1_cart_opens",
+                "Type": "Custom",
+                "Field": "cq_m1_cart_opens",
+                "VariableType": "String",
+                "DataVisibility": {
+                  "Hidden": false,
+                  "Private": false
+                },
+                "AnalyzeText": false,
+                "Value": ""
+              },
+              {
+                "Description": "cq_m1_complete",
+                "Type": "Custom",
+                "Field": "cq_m1_complete",
+                "VariableType": "String",
+                "DataVisibility": {
+                  "Hidden": false,
+                  "Private": false
+                },
+                "AnalyzeText": false,
+                "Value": ""
+              },
+              {
+                "Description": "cq_m2_scenario",
+                "Type": "Custom",
+                "Field": "cq_m2_scenario",
+                "VariableType": "String",
+                "DataVisibility": {
+                  "Hidden": false,
+                  "Private": false
+                },
+                "AnalyzeText": false,
+                "Value": ""
+              },
+              {
+                "Description": "cq_m2_time",
+                "Type": "Custom",
+                "Field": "cq_m2_time",
+                "VariableType": "String",
+                "DataVisibility": {
+                  "Hidden": false,
+                  "Private": false
+                },
+                "AnalyzeText": false,
+                "Value": ""
+              },
+              {
+                "Description": "cq_m2_score",
+                "Type": "Custom",
+                "Field": "cq_m2_score",
+                "VariableType": "String",
+                "DataVisibility": {
+                  "Hidden": false,
+                  "Private": false
+                },
+                "AnalyzeText": false,
+                "Value": ""
+              },
+              {
+                "Description": "cq_m2_stars",
+                "Type": "Custom",
+                "Field": "cq_m2_stars",
+                "VariableType": "String",
+                "DataVisibility": {
+                  "Hidden": false,
+                  "Private": false
+                },
+                "AnalyzeText": false,
+                "Value": ""
+              },
+              {
+                "Description": "cq_m2_ess_found",
+                "Type": "Custom",
+                "Field": "cq_m2_ess_found",
+                "VariableType": "String",
+                "DataVisibility": {
+                  "Hidden": false,
+                  "Private": false
+                },
+                "AnalyzeText": false,
+                "Value": ""
+              },
+              {
+                "Description": "cq_m2_ess_total",
+                "Type": "Custom",
+                "Field": "cq_m2_ess_total",
+                "VariableType": "String",
+                "DataVisibility": {
+                  "Hidden": false,
+                  "Private": false
+                },
+                "AnalyzeText": false,
+                "Value": ""
+              },
+              {
+                "Description": "cq_m2_opt_found",
+                "Type": "Custom",
+                "Field": "cq_m2_opt_found",
+                "VariableType": "String",
+                "DataVisibility": {
+                  "Hidden": false,
+                  "Private": false
+                },
+                "AnalyzeText": false,
+                "Value": ""
+              },
+              {
+                "Description": "cq_m2_opt_total",
+                "Type": "Custom",
+                "Field": "cq_m2_opt_total",
+                "VariableType": "String",
+                "DataVisibility": {
+                  "Hidden": false,
+                  "Private": false
+                },
+                "AnalyzeText": false,
+                "Value": ""
+              },
+              {
+                "Description": "cq_m2_extra",
+                "Type": "Custom",
+                "Field": "cq_m2_extra",
+                "VariableType": "String",
+                "DataVisibility": {
+                  "Hidden": false,
+                  "Private": false
+                },
+                "AnalyzeText": false,
+                "Value": ""
+              },
+              {
+                "Description": "cq_m2_missed_ess",
+                "Type": "Custom",
+                "Field": "cq_m2_missed_ess",
+                "VariableType": "String",
+                "DataVisibility": {
+                  "Hidden": false,
+                  "Private": false
+                },
+                "AnalyzeText": false,
+                "Value": ""
+              },
+              {
+                "Description": "cq_m2_correct",
+                "Type": "Custom",
+                "Field": "cq_m2_correct",
+                "VariableType": "String",
+                "DataVisibility": {
+                  "Hidden": false,
+                  "Private": false
+                },
+                "AnalyzeText": false,
+                "Value": ""
+              },
+              {
+                "Description": "cq_m2_incorrect",
+                "Type": "Custom",
+                "Field": "cq_m2_incorrect",
+                "VariableType": "String",
+                "DataVisibility": {
+                  "Hidden": false,
+                  "Private": false
+                },
+                "AnalyzeText": false,
+                "Value": ""
+              },
+              {
+                "Description": "cq_m2_accuracy",
+                "Type": "Custom",
+                "Field": "cq_m2_accuracy",
+                "VariableType": "String",
+                "DataVisibility": {
+                  "Hidden": false,
+                  "Private": false
+                },
+                "AnalyzeText": false,
+                "Value": ""
+              },
+              {
+                "Description": "cq_m2_drawers_opened",
+                "Type": "Custom",
+                "Field": "cq_m2_drawers_opened",
+                "VariableType": "String",
+                "DataVisibility": {
+                  "Hidden": false,
+                  "Private": false
+                },
+                "AnalyzeText": false,
+                "Value": ""
+              },
+              {
+                "Description": "cq_m2_distinct_drawers",
+                "Type": "Custom",
+                "Field": "cq_m2_distinct_drawers",
+                "VariableType": "String",
+                "DataVisibility": {
+                  "Hidden": false,
+                  "Private": false
+                },
+                "AnalyzeText": false,
+                "Value": ""
+              },
+              {
+                "Description": "cq_m2_cart_opens",
+                "Type": "Custom",
+                "Field": "cq_m2_cart_opens",
+                "VariableType": "String",
+                "DataVisibility": {
+                  "Hidden": false,
+                  "Private": false
+                },
+                "AnalyzeText": false,
+                "Value": ""
+              },
+              {
+                "Description": "cq_m2_complete",
+                "Type": "Custom",
+                "Field": "cq_m2_complete",
+                "VariableType": "String",
+                "DataVisibility": {
+                  "Hidden": false,
+                  "Private": false
+                },
+                "AnalyzeText": false,
+                "Value": ""
+              },
+              {
+                "Description": "cq_m3_scenario",
+                "Type": "Custom",
+                "Field": "cq_m3_scenario",
+                "VariableType": "String",
+                "DataVisibility": {
+                  "Hidden": false,
+                  "Private": false
+                },
+                "AnalyzeText": false,
+                "Value": ""
+              },
+              {
+                "Description": "cq_m3_time",
+                "Type": "Custom",
+                "Field": "cq_m3_time",
+                "VariableType": "String",
+                "DataVisibility": {
+                  "Hidden": false,
+                  "Private": false
+                },
+                "AnalyzeText": false,
+                "Value": ""
+              },
+              {
+                "Description": "cq_m3_score",
+                "Type": "Custom",
+                "Field": "cq_m3_score",
+                "VariableType": "String",
+                "DataVisibility": {
+                  "Hidden": false,
+                  "Private": false
+                },
+                "AnalyzeText": false,
+                "Value": ""
+              },
+              {
+                "Description": "cq_m3_stars",
+                "Type": "Custom",
+                "Field": "cq_m3_stars",
+                "VariableType": "String",
+                "DataVisibility": {
+                  "Hidden": false,
+                  "Private": false
+                },
+                "AnalyzeText": false,
+                "Value": ""
+              },
+              {
+                "Description": "cq_m3_ess_found",
+                "Type": "Custom",
+                "Field": "cq_m3_ess_found",
+                "VariableType": "String",
+                "DataVisibility": {
+                  "Hidden": false,
+                  "Private": false
+                },
+                "AnalyzeText": false,
+                "Value": ""
+              },
+              {
+                "Description": "cq_m3_ess_total",
+                "Type": "Custom",
+                "Field": "cq_m3_ess_total",
+                "VariableType": "String",
+                "DataVisibility": {
+                  "Hidden": false,
+                  "Private": false
+                },
+                "AnalyzeText": false,
+                "Value": ""
+              },
+              {
+                "Description": "cq_m3_opt_found",
+                "Type": "Custom",
+                "Field": "cq_m3_opt_found",
+                "VariableType": "String",
+                "DataVisibility": {
+                  "Hidden": false,
+                  "Private": false
+                },
+                "AnalyzeText": false,
+                "Value": ""
+              },
+              {
+                "Description": "cq_m3_opt_total",
+                "Type": "Custom",
+                "Field": "cq_m3_opt_total",
+                "VariableType": "String",
+                "DataVisibility": {
+                  "Hidden": false,
+                  "Private": false
+                },
+                "AnalyzeText": false,
+                "Value": ""
+              },
+              {
+                "Description": "cq_m3_extra",
+                "Type": "Custom",
+                "Field": "cq_m3_extra",
+                "VariableType": "String",
+                "DataVisibility": {
+                  "Hidden": false,
+                  "Private": false
+                },
+                "AnalyzeText": false,
+                "Value": ""
+              },
+              {
+                "Description": "cq_m3_missed_ess",
+                "Type": "Custom",
+                "Field": "cq_m3_missed_ess",
+                "VariableType": "String",
+                "DataVisibility": {
+                  "Hidden": false,
+                  "Private": false
+                },
+                "AnalyzeText": false,
+                "Value": ""
+              },
+              {
+                "Description": "cq_m3_correct",
+                "Type": "Custom",
+                "Field": "cq_m3_correct",
+                "VariableType": "String",
+                "DataVisibility": {
+                  "Hidden": false,
+                  "Private": false
+                },
+                "AnalyzeText": false,
+                "Value": ""
+              },
+              {
+                "Description": "cq_m3_incorrect",
+                "Type": "Custom",
+                "Field": "cq_m3_incorrect",
+                "VariableType": "String",
+                "DataVisibility": {
+                  "Hidden": false,
+                  "Private": false
+                },
+                "AnalyzeText": false,
+                "Value": ""
+              },
+              {
+                "Description": "cq_m3_accuracy",
+                "Type": "Custom",
+                "Field": "cq_m3_accuracy",
+                "VariableType": "String",
+                "DataVisibility": {
+                  "Hidden": false,
+                  "Private": false
+                },
+                "AnalyzeText": false,
+                "Value": ""
+              },
+              {
+                "Description": "cq_m3_drawers_opened",
+                "Type": "Custom",
+                "Field": "cq_m3_drawers_opened",
+                "VariableType": "String",
+                "DataVisibility": {
+                  "Hidden": false,
+                  "Private": false
+                },
+                "AnalyzeText": false,
+                "Value": ""
+              },
+              {
+                "Description": "cq_m3_distinct_drawers",
+                "Type": "Custom",
+                "Field": "cq_m3_distinct_drawers",
+                "VariableType": "String",
+                "DataVisibility": {
+                  "Hidden": false,
+                  "Private": false
+                },
+                "AnalyzeText": false,
+                "Value": ""
+              },
+              {
+                "Description": "cq_m3_cart_opens",
+                "Type": "Custom",
+                "Field": "cq_m3_cart_opens",
+                "VariableType": "String",
+                "DataVisibility": {
+                  "Hidden": false,
+                  "Private": false
+                },
+                "AnalyzeText": false,
+                "Value": ""
+              },
+              {
+                "Description": "cq_m3_complete",
+                "Type": "Custom",
+                "Field": "cq_m3_complete",
+                "VariableType": "String",
+                "DataVisibility": {
+                  "Hidden": false,
+                  "Private": false
+                },
+                "AnalyzeText": false,
+                "Value": ""
+              },
+              {
+                "Description": "cq_tut_completed",
+                "Type": "Custom",
+                "Field": "cq_tut_completed",
+                "VariableType": "String",
+                "DataVisibility": {
+                  "Hidden": false,
+                  "Private": false
+                },
+                "AnalyzeText": false,
+                "Value": ""
+              },
+              {
+                "Description": "cq_tut_time",
+                "Type": "Custom",
+                "Field": "cq_tut_time",
+                "VariableType": "String",
+                "DataVisibility": {
+                  "Hidden": false,
+                  "Private": false
+                },
+                "AnalyzeText": false,
+                "Value": ""
+              },
+              {
+                "Description": "cq_app_version",
+                "Type": "Custom",
+                "Field": "cq_app_version",
+                "VariableType": "String",
+                "DataVisibility": {
+                  "Hidden": false,
+                  "Private": false
+                },
+                "AnalyzeText": false,
+                "Value": ""
+              },
+              {
+                "Description": "cq_mode",
+                "Type": "Custom",
+                "Field": "cq_mode",
+                "VariableType": "String",
+                "DataVisibility": {
+                  "Hidden": false,
+                  "Private": false
+                },
+                "AnalyzeText": false,
+                "Value": ""
+              },
+              {
+                "Description": "cq_log_tutorial",
+                "Type": "Custom",
+                "Field": "cq_log_tutorial",
+                "VariableType": "String",
+                "DataVisibility": {
+                  "Hidden": false,
+                  "Private": false
+                },
+                "AnalyzeText": false,
+                "Value": ""
+              },
+              {
+                "Description": "cq_log_m1",
+                "Type": "Custom",
+                "Field": "cq_log_m1",
+                "VariableType": "String",
+                "DataVisibility": {
+                  "Hidden": false,
+                  "Private": false
+                },
+                "AnalyzeText": false,
+                "Value": ""
+              },
+              {
+                "Description": "cq_log_m2",
+                "Type": "Custom",
+                "Field": "cq_log_m2",
+                "VariableType": "String",
+                "DataVisibility": {
+                  "Hidden": false,
+                  "Private": false
+                },
+                "AnalyzeText": false,
+                "Value": ""
+              },
+              {
+                "Description": "cq_log_m3",
+                "Type": "Custom",
+                "Field": "cq_log_m3",
+                "VariableType": "String",
+                "DataVisibility": {
+                  "Hidden": false,
+                  "Private": false
+                },
+                "AnalyzeText": false,
+                "Value": ""
+              }
+            ]
+          },
+          {
+            "Type": "Block",
+            "ID": "BL_consent",
+            "FlowID": "FL_3",
+            "Autofill": []
+          },
+          {
+            "Type": "Block",
+            "ID": "BL_tut",
+            "FlowID": "FL_4",
+            "Autofill": []
+          },
+          {
+            "Type": "Block",
+            "ID": "BL_tutq",
+            "FlowID": "FL_5",
+            "Autofill": []
+          },
+          {
+            "Type": "Block",
+            "ID": "BL_s1",
+            "FlowID": "FL_6",
+            "Autofill": []
+          },
+          {
+            "Type": "Block",
+            "ID": "BL_s1q",
+            "FlowID": "FL_7",
+            "Autofill": []
+          },
+          {
+            "Type": "Block",
+            "ID": "BL_s2",
+            "FlowID": "FL_8",
+            "Autofill": []
+          },
+          {
+            "Type": "Block",
+            "ID": "BL_s2q",
+            "FlowID": "FL_9",
+            "Autofill": []
+          },
+          {
+            "Type": "Block",
+            "ID": "BL_s3",
+            "FlowID": "FL_10",
+            "Autofill": []
+          },
+          {
+            "Type": "Block",
+            "ID": "BL_s3q",
+            "FlowID": "FL_11",
+            "Autofill": []
+          },
+          {
+            "Type": "Block",
+            "ID": "BL_post",
+            "FlowID": "FL_12",
+            "Autofill": []
+          }
+        ],
+        "Properties": {
+          "Count": 12,
+          "RemovedFieldsets": []
+        },
+        "FlowID": "FL_1",
+        "Type": "Root"
+      }
+    },
+    {
+      "SurveyID": "SV_CabinetQuestStudy01",
+      "Element": "BL",
+      "PrimaryAttribute": "Survey Blocks",
+      "SecondaryAttribute": null,
+      "TertiaryAttribute": null,
+      "Payload": [
+        {
+          "Type": "Standard",
+          "SubType": "",
+          "Description": "Consent & Intake",
+          "ID": "BL_consent",
+          "BlockElements": [
+            {
+              "Type": "Question",
+              "QuestionID": "QID1"
+            }
+          ],
+          "Options": {
+            "BlockLocking": "false",
+            "RandomizeQuestions": "false",
+            "BlockVisibility": "Expanded"
+          }
+        },
+        {
+          "Type": "Standard",
+          "SubType": "",
+          "Description": "Tutorial",
+          "ID": "BL_tut",
+          "BlockElements": [
+            {
+              "Type": "Question",
+              "QuestionID": "QID2"
+            }
+          ],
+          "Options": {
+            "BlockLocking": "false",
+            "RandomizeQuestions": "false",
+            "BlockVisibility": "Expanded"
+          }
+        },
+        {
+          "Type": "Standard",
+          "SubType": "",
+          "Description": "Tutorial Questions",
+          "ID": "BL_tutq",
+          "BlockElements": [
+            {
+              "Type": "Question",
+              "QuestionID": "QID3"
+            }
+          ],
+          "Options": {
+            "BlockLocking": "false",
+            "RandomizeQuestions": "false",
+            "BlockVisibility": "Expanded"
+          }
+        },
+        {
+          "Type": "Standard",
+          "SubType": "",
+          "Description": "Scenario 1",
+          "ID": "BL_s1",
+          "BlockElements": [
+            {
+              "Type": "Question",
+              "QuestionID": "QID4"
+            }
+          ],
+          "Options": {
+            "BlockLocking": "false",
+            "RandomizeQuestions": "false",
+            "BlockVisibility": "Expanded"
+          }
+        },
+        {
+          "Type": "Standard",
+          "SubType": "",
+          "Description": "Scenario 1 Questions",
+          "ID": "BL_s1q",
+          "BlockElements": [
+            {
+              "Type": "Question",
+              "QuestionID": "QID5"
+            }
+          ],
+          "Options": {
+            "BlockLocking": "false",
+            "RandomizeQuestions": "false",
+            "BlockVisibility": "Expanded"
+          }
+        },
+        {
+          "Type": "Standard",
+          "SubType": "",
+          "Description": "Scenario 2",
+          "ID": "BL_s2",
+          "BlockElements": [
+            {
+              "Type": "Question",
+              "QuestionID": "QID6"
+            }
+          ],
+          "Options": {
+            "BlockLocking": "false",
+            "RandomizeQuestions": "false",
+            "BlockVisibility": "Expanded"
+          }
+        },
+        {
+          "Type": "Standard",
+          "SubType": "",
+          "Description": "Scenario 2 Questions",
+          "ID": "BL_s2q",
+          "BlockElements": [
+            {
+              "Type": "Question",
+              "QuestionID": "QID7"
+            }
+          ],
+          "Options": {
+            "BlockLocking": "false",
+            "RandomizeQuestions": "false",
+            "BlockVisibility": "Expanded"
+          }
+        },
+        {
+          "Type": "Standard",
+          "SubType": "",
+          "Description": "Scenario 3",
+          "ID": "BL_s3",
+          "BlockElements": [
+            {
+              "Type": "Question",
+              "QuestionID": "QID8"
+            }
+          ],
+          "Options": {
+            "BlockLocking": "false",
+            "RandomizeQuestions": "false",
+            "BlockVisibility": "Expanded"
+          }
+        },
+        {
+          "Type": "Standard",
+          "SubType": "",
+          "Description": "Scenario 3 Questions",
+          "ID": "BL_s3q",
+          "BlockElements": [
+            {
+              "Type": "Question",
+              "QuestionID": "QID9"
+            }
+          ],
+          "Options": {
+            "BlockLocking": "false",
+            "RandomizeQuestions": "false",
+            "BlockVisibility": "Expanded"
+          }
+        },
+        {
+          "Type": "Standard",
+          "SubType": "",
+          "Description": "Post-Intervention",
+          "ID": "BL_post",
+          "BlockElements": [
+            {
+              "Type": "Question",
+              "QuestionID": "QID10"
+            }
+          ],
+          "Options": {
+            "BlockLocking": "false",
+            "RandomizeQuestions": "false",
+            "BlockVisibility": "Expanded"
+          }
+        }
+      ]
+    },
+    {
+      "SurveyID": "SV_CabinetQuestStudy01",
+      "Element": "SO",
+      "PrimaryAttribute": "Survey Options",
+      "SecondaryAttribute": null,
+      "TertiaryAttribute": null,
+      "Payload": {
+        "BackButton": "false",
+        "SaveAndContinue": "true",
+        "SurveyProtection": "PublicSurvey",
+        "BallotBoxStuffingPrevention": "false",
+        "NoIndex": "Yes",
+        "SecureResponseFiles": "true",
+        "SurveyExpiration": "None",
+        "SurveyTermination": "DefaultMessage",
+        "Header": "",
+        "Footer": "",
+        "ProgressBarDisplay": "Text",
+        "PartialData": "+1 week",
+        "ValidationMessage": "",
+        "PreviousButton": "",
+        "NextButton": "Next  →",
+        "SurveyTitle": "Cabinet Quest Study",
+        "SkinLibrary": "qualtrics",
+        "SkinType": "templated",
+        "Skin": {
+          "brandingId": null,
+          "templateId": null,
+          "overrides": null
+        },
+        "NewScoring": 1
+      }
+    },
+    {
+      "SurveyID": "SV_CabinetQuestStudy01",
+      "Element": "SQ",
+      "PrimaryAttribute": "QID1",
+      "SecondaryAttribute": "intro_consent",
+      "TertiaryAttribute": null,
+      "Payload": {
+        "QuestionText": "<h3>Welcome &amp; Consent</h3><p><em>[Replace this block with your IRB-approved consent and intake/panel items. The participant's session key (<code>sid</code>) is set automatically in the Survey Flow and carried through every page.]</em></p>",
+        "QuestionText_Unsafe": "<h3>Welcome &amp; Consent</h3><p><em>[Replace this block with your IRB-approved consent and intake/panel items. The participant's session key (<code>sid</code>) is set automatically in the Survey Flow and carried through every page.]</em></p>",
+        "DataExportTag": "intro_consent",
+        "QuestionType": "DB",
+        "Selector": "TB",
+        "SubSelector": "",
+        "Configuration": {
+          "QuestionDescriptionOption": "UseText"
+        },
+        "QuestionDescription": "intro_consent",
+        "ChoiceOrder": [],
+        "Validation": {
+          "Settings": {
+            "Type": "None"
+          }
+        },
+        "DataVisibility": {
+          "Private": false,
+          "Hidden": false
+        },
+        "QuestionID": "QID1"
+      }
+    },
+    {
+      "SurveyID": "SV_CabinetQuestStudy01",
+      "Element": "SQ",
+      "PrimaryAttribute": "QID2",
+      "SecondaryAttribute": "game_tutorial",
+      "TertiaryAttribute": null,
+      "Payload": {
+        "QuestionText": "<strong>Tutorial</strong> — follow the on-screen coach marks to learn the controls.",
+        "QuestionText_Unsafe": "<strong>Tutorial</strong> — follow the on-screen coach marks to learn the controls.",
+        "DataExportTag": "game_tutorial",
+        "QuestionType": "DB",
+        "Selector": "TB",
+        "SubSelector": "",
+        "Configuration": {
+          "QuestionDescriptionOption": "UseText"
+        },
+        "QuestionDescription": "game_tutorial",
+        "ChoiceOrder": [],
+        "Validation": {
+          "Settings": {
+            "Type": "None"
+          }
+        },
+        "DataVisibility": {
+          "Private": false,
+          "Hidden": false
+        },
+        "QuestionID": "QID2",
+        "QuestionJS": "Qualtrics.SurveyEngine.addOnload(function () {\n    var GITHUB_ORIGIN = 'https://christiantreat.github.io';\n    var APP_URL = 'https://christiantreat.github.io/CabinetQuest/';\n    var QUERY = 'phase=tutorial';          // phase for this survey page\n    var LOG_FIELD = 'cq_log_tutorial';   // embedded-data field for this page's event log\n    var self = this;\n\n    var sid = '${e://Field/sid}';\n    if (!sid || sid.indexOf('://') !== -1) { sid = 'demo-' + Date.now(); }\n\n    // Insert the game iframe for this phase (sid + phase passed in the URL).\n    var container = (this.getQuestionContainer ? this.getQuestionContainer() : this.questionContainer);\n    var frame = document.createElement('iframe');\n    frame.src = APP_URL + '?sid=' + encodeURIComponent(sid) + '&' + QUERY;\n    frame.style.width = '100%'; frame.style.height = '80vh';\n    frame.style.minHeight = '600px'; frame.style.border = '0';\n    frame.setAttribute('allow', 'fullscreen'); frame.title = 'Cabinet Quest';\n    if (container && container.appendChild) container.appendChild(frame);\n\n    // Force participants to play: hide Next until the phase reports complete.\n    // (Comment out the next line if you want a manual Next as a fallback.)\n    try { var nb = document.getElementById('NextButton'); if (nb) nb.style.display = 'none'; } catch (e) {}\n\n    function handler(event) {\n        if (event.origin !== GITHUB_ORIGIN) { return; }\n        var data = event.data;\n        if (!data || data.source !== 'codesbu') { return; }\n\n        if (data.summary && typeof data.summary === 'object') {\n            for (var key in data.summary) {\n                if (Object.prototype.hasOwnProperty.call(data.summary, key)) {\n                    Qualtrics.SurveyEngine.setEmbeddedData(key, data.summary[key]);\n                }\n            }\n        }\n        if (data.sid) { Qualtrics.SurveyEngine.setEmbeddedData('sid', data.sid); }\n\n        // session_complete = this phase is done -> store its log and advance.\n        if (data.type === 'session_complete') {\n            if (data.log) { Qualtrics.SurveyEngine.setEmbeddedData(LOG_FIELD, data.log); }\n            try { var nb2 = document.getElementById('NextButton'); if (nb2) nb2.style.display = ''; } catch (e) {}\n            try { self.clickNextButton(); } catch (e) {}\n        }\n    }\n    window.addEventListener('message', handler, false);\n    this.__cqHandler = handler;\n});\n\nQualtrics.SurveyEngine.addOnUnload(function () {\n    if (this.__cqHandler) { window.removeEventListener('message', this.__cqHandler, false); }\n});"
+      }
+    },
+    {
+      "SurveyID": "SV_CabinetQuestStudy01",
+      "Element": "SQ",
+      "PrimaryAttribute": "QID3",
+      "SecondaryAttribute": "q_tutorial",
+      "TertiaryAttribute": null,
+      "Payload": {
+        "QuestionText": "How clear were the game controls after the tutorial?",
+        "QuestionText_Unsafe": "How clear were the game controls after the tutorial?",
+        "DataExportTag": "q_tutorial",
+        "QuestionType": "MC",
+        "Selector": "SAVR",
+        "SubSelector": "TX",
+        "Configuration": {
+          "QuestionDescriptionOption": "UseText"
+        },
+        "QuestionDescription": "How clear were the game controls after the tutorial?",
+        "Choices": {
+          "1": {
+            "Display": "1 – Not at all"
+          },
+          "2": {
+            "Display": "2"
+          },
+          "3": {
+            "Display": "3"
+          },
+          "4": {
+            "Display": "4"
+          },
+          "5": {
+            "Display": "5 – Extremely"
+          }
+        },
+        "ChoiceOrder": [
+          "1",
+          "2",
+          "3",
+          "4",
+          "5"
+        ],
+        "Validation": {
+          "Settings": {
+            "ForceResponse": "OFF",
+            "Type": "None"
+          }
+        },
+        "Language": [],
+        "NextChoiceId": 6,
+        "NextAnswerId": 1,
+        "QuestionID": "QID3",
+        "DataVisibility": {
+          "Private": false,
+          "Hidden": false
+        }
+      }
+    },
+    {
+      "SurveyID": "SV_CabinetQuestStudy01",
+      "Element": "SQ",
+      "PrimaryAttribute": "QID4",
+      "SecondaryAttribute": "game_s1",
+      "TertiaryAttribute": null,
+      "Payload": {
+        "QuestionText": "<strong>Scenario 1: Arterial Line Placement</strong> — gather the required equipment, then Submit.",
+        "QuestionText_Unsafe": "<strong>Scenario 1: Arterial Line Placement</strong> — gather the required equipment, then Submit.",
+        "DataExportTag": "game_s1",
+        "QuestionType": "DB",
+        "Selector": "TB",
+        "SubSelector": "",
+        "Configuration": {
+          "QuestionDescriptionOption": "UseText"
+        },
+        "QuestionDescription": "game_s1",
+        "ChoiceOrder": [],
+        "Validation": {
+          "Settings": {
+            "Type": "None"
+          }
+        },
+        "DataVisibility": {
+          "Private": false,
+          "Hidden": false
+        },
+        "QuestionID": "QID4",
+        "QuestionJS": "Qualtrics.SurveyEngine.addOnload(function () {\n    var GITHUB_ORIGIN = 'https://christiantreat.github.io';\n    var APP_URL = 'https://christiantreat.github.io/CabinetQuest/';\n    var QUERY = 'phase=scenario&scenario=s4';          // phase for this survey page\n    var LOG_FIELD = 'cq_log_m1';   // embedded-data field for this page's event log\n    var self = this;\n\n    var sid = '${e://Field/sid}';\n    if (!sid || sid.indexOf('://') !== -1) { sid = 'demo-' + Date.now(); }\n\n    // Insert the game iframe for this phase (sid + phase passed in the URL).\n    var container = (this.getQuestionContainer ? this.getQuestionContainer() : this.questionContainer);\n    var frame = document.createElement('iframe');\n    frame.src = APP_URL + '?sid=' + encodeURIComponent(sid) + '&' + QUERY;\n    frame.style.width = '100%'; frame.style.height = '80vh';\n    frame.style.minHeight = '600px'; frame.style.border = '0';\n    frame.setAttribute('allow', 'fullscreen'); frame.title = 'Cabinet Quest';\n    if (container && container.appendChild) container.appendChild(frame);\n\n    // Force participants to play: hide Next until the phase reports complete.\n    // (Comment out the next line if you want a manual Next as a fallback.)\n    try { var nb = document.getElementById('NextButton'); if (nb) nb.style.display = 'none'; } catch (e) {}\n\n    function handler(event) {\n        if (event.origin !== GITHUB_ORIGIN) { return; }\n        var data = event.data;\n        if (!data || data.source !== 'codesbu') { return; }\n\n        if (data.summary && typeof data.summary === 'object') {\n            for (var key in data.summary) {\n                if (Object.prototype.hasOwnProperty.call(data.summary, key)) {\n                    Qualtrics.SurveyEngine.setEmbeddedData(key, data.summary[key]);\n                }\n            }\n        }\n        if (data.sid) { Qualtrics.SurveyEngine.setEmbeddedData('sid', data.sid); }\n\n        // session_complete = this phase is done -> store its log and advance.\n        if (data.type === 'session_complete') {\n            if (data.log) { Qualtrics.SurveyEngine.setEmbeddedData(LOG_FIELD, data.log); }\n            try { var nb2 = document.getElementById('NextButton'); if (nb2) nb2.style.display = ''; } catch (e) {}\n            try { self.clickNextButton(); } catch (e) {}\n        }\n    }\n    window.addEventListener('message', handler, false);\n    this.__cqHandler = handler;\n});\n\nQualtrics.SurveyEngine.addOnUnload(function () {\n    if (this.__cqHandler) { window.removeEventListener('message', this.__cqHandler, false); }\n});"
+      }
+    },
+    {
+      "SurveyID": "SV_CabinetQuestStudy01",
+      "Element": "SQ",
+      "PrimaryAttribute": "QID5",
+      "SecondaryAttribute": "q_s1",
+      "TertiaryAttribute": null,
+      "Payload": {
+        "QuestionText": "How confident were you completing Scenario 1?",
+        "QuestionText_Unsafe": "How confident were you completing Scenario 1?",
+        "DataExportTag": "q_s1",
+        "QuestionType": "MC",
+        "Selector": "SAVR",
+        "SubSelector": "TX",
+        "Configuration": {
+          "QuestionDescriptionOption": "UseText"
+        },
+        "QuestionDescription": "How confident were you completing Scenario 1?",
+        "Choices": {
+          "1": {
+            "Display": "1 – Not at all"
+          },
+          "2": {
+            "Display": "2"
+          },
+          "3": {
+            "Display": "3"
+          },
+          "4": {
+            "Display": "4"
+          },
+          "5": {
+            "Display": "5 – Extremely"
+          }
+        },
+        "ChoiceOrder": [
+          "1",
+          "2",
+          "3",
+          "4",
+          "5"
+        ],
+        "Validation": {
+          "Settings": {
+            "ForceResponse": "OFF",
+            "Type": "None"
+          }
+        },
+        "Language": [],
+        "NextChoiceId": 6,
+        "NextAnswerId": 1,
+        "QuestionID": "QID5",
+        "DataVisibility": {
+          "Private": false,
+          "Hidden": false
+        }
+      }
+    },
+    {
+      "SurveyID": "SV_CabinetQuestStudy01",
+      "Element": "SQ",
+      "PrimaryAttribute": "QID6",
+      "SecondaryAttribute": "game_s2",
+      "TertiaryAttribute": null,
+      "Payload": {
+        "QuestionText": "<strong>Scenario 2: Central Line Placement</strong> — gather the required equipment, then Submit.",
+        "QuestionText_Unsafe": "<strong>Scenario 2: Central Line Placement</strong> — gather the required equipment, then Submit.",
+        "DataExportTag": "game_s2",
+        "QuestionType": "DB",
+        "Selector": "TB",
+        "SubSelector": "",
+        "Configuration": {
+          "QuestionDescriptionOption": "UseText"
+        },
+        "QuestionDescription": "game_s2",
+        "ChoiceOrder": [],
+        "Validation": {
+          "Settings": {
+            "Type": "None"
+          }
+        },
+        "DataVisibility": {
+          "Private": false,
+          "Hidden": false
+        },
+        "QuestionID": "QID6",
+        "QuestionJS": "Qualtrics.SurveyEngine.addOnload(function () {\n    var GITHUB_ORIGIN = 'https://christiantreat.github.io';\n    var APP_URL = 'https://christiantreat.github.io/CabinetQuest/';\n    var QUERY = 'phase=scenario&scenario=s2';          // phase for this survey page\n    var LOG_FIELD = 'cq_log_m2';   // embedded-data field for this page's event log\n    var self = this;\n\n    var sid = '${e://Field/sid}';\n    if (!sid || sid.indexOf('://') !== -1) { sid = 'demo-' + Date.now(); }\n\n    // Insert the game iframe for this phase (sid + phase passed in the URL).\n    var container = (this.getQuestionContainer ? this.getQuestionContainer() : this.questionContainer);\n    var frame = document.createElement('iframe');\n    frame.src = APP_URL + '?sid=' + encodeURIComponent(sid) + '&' + QUERY;\n    frame.style.width = '100%'; frame.style.height = '80vh';\n    frame.style.minHeight = '600px'; frame.style.border = '0';\n    frame.setAttribute('allow', 'fullscreen'); frame.title = 'Cabinet Quest';\n    if (container && container.appendChild) container.appendChild(frame);\n\n    // Force participants to play: hide Next until the phase reports complete.\n    // (Comment out the next line if you want a manual Next as a fallback.)\n    try { var nb = document.getElementById('NextButton'); if (nb) nb.style.display = 'none'; } catch (e) {}\n\n    function handler(event) {\n        if (event.origin !== GITHUB_ORIGIN) { return; }\n        var data = event.data;\n        if (!data || data.source !== 'codesbu') { return; }\n\n        if (data.summary && typeof data.summary === 'object') {\n            for (var key in data.summary) {\n                if (Object.prototype.hasOwnProperty.call(data.summary, key)) {\n                    Qualtrics.SurveyEngine.setEmbeddedData(key, data.summary[key]);\n                }\n            }\n        }\n        if (data.sid) { Qualtrics.SurveyEngine.setEmbeddedData('sid', data.sid); }\n\n        // session_complete = this phase is done -> store its log and advance.\n        if (data.type === 'session_complete') {\n            if (data.log) { Qualtrics.SurveyEngine.setEmbeddedData(LOG_FIELD, data.log); }\n            try { var nb2 = document.getElementById('NextButton'); if (nb2) nb2.style.display = ''; } catch (e) {}\n            try { self.clickNextButton(); } catch (e) {}\n        }\n    }\n    window.addEventListener('message', handler, false);\n    this.__cqHandler = handler;\n});\n\nQualtrics.SurveyEngine.addOnUnload(function () {\n    if (this.__cqHandler) { window.removeEventListener('message', this.__cqHandler, false); }\n});"
+      }
+    },
+    {
+      "SurveyID": "SV_CabinetQuestStudy01",
+      "Element": "SQ",
+      "PrimaryAttribute": "QID7",
+      "SecondaryAttribute": "q_s2",
+      "TertiaryAttribute": null,
+      "Payload": {
+        "QuestionText": "How confident were you completing Scenario 2?",
+        "QuestionText_Unsafe": "How confident were you completing Scenario 2?",
+        "DataExportTag": "q_s2",
+        "QuestionType": "MC",
+        "Selector": "SAVR",
+        "SubSelector": "TX",
+        "Configuration": {
+          "QuestionDescriptionOption": "UseText"
+        },
+        "QuestionDescription": "How confident were you completing Scenario 2?",
+        "Choices": {
+          "1": {
+            "Display": "1 – Not at all"
+          },
+          "2": {
+            "Display": "2"
+          },
+          "3": {
+            "Display": "3"
+          },
+          "4": {
+            "Display": "4"
+          },
+          "5": {
+            "Display": "5 – Extremely"
+          }
+        },
+        "ChoiceOrder": [
+          "1",
+          "2",
+          "3",
+          "4",
+          "5"
+        ],
+        "Validation": {
+          "Settings": {
+            "ForceResponse": "OFF",
+            "Type": "None"
+          }
+        },
+        "Language": [],
+        "NextChoiceId": 6,
+        "NextAnswerId": 1,
+        "QuestionID": "QID7",
+        "DataVisibility": {
+          "Private": false,
+          "Hidden": false
+        }
+      }
+    },
+    {
+      "SurveyID": "SV_CabinetQuestStudy01",
+      "Element": "SQ",
+      "PrimaryAttribute": "QID8",
+      "SecondaryAttribute": "game_s3",
+      "TertiaryAttribute": null,
+      "Payload": {
+        "QuestionText": "<strong>Scenario 3: Chest Tube Insertion</strong> — gather the required equipment, then Submit.",
+        "QuestionText_Unsafe": "<strong>Scenario 3: Chest Tube Insertion</strong> — gather the required equipment, then Submit.",
+        "DataExportTag": "game_s3",
+        "QuestionType": "DB",
+        "Selector": "TB",
+        "SubSelector": "",
+        "Configuration": {
+          "QuestionDescriptionOption": "UseText"
+        },
+        "QuestionDescription": "game_s3",
+        "ChoiceOrder": [],
+        "Validation": {
+          "Settings": {
+            "Type": "None"
+          }
+        },
+        "DataVisibility": {
+          "Private": false,
+          "Hidden": false
+        },
+        "QuestionID": "QID8",
+        "QuestionJS": "Qualtrics.SurveyEngine.addOnload(function () {\n    var GITHUB_ORIGIN = 'https://christiantreat.github.io';\n    var APP_URL = 'https://christiantreat.github.io/CabinetQuest/';\n    var QUERY = 'phase=scenario&scenario=s3';          // phase for this survey page\n    var LOG_FIELD = 'cq_log_m3';   // embedded-data field for this page's event log\n    var self = this;\n\n    var sid = '${e://Field/sid}';\n    if (!sid || sid.indexOf('://') !== -1) { sid = 'demo-' + Date.now(); }\n\n    // Insert the game iframe for this phase (sid + phase passed in the URL).\n    var container = (this.getQuestionContainer ? this.getQuestionContainer() : this.questionContainer);\n    var frame = document.createElement('iframe');\n    frame.src = APP_URL + '?sid=' + encodeURIComponent(sid) + '&' + QUERY;\n    frame.style.width = '100%'; frame.style.height = '80vh';\n    frame.style.minHeight = '600px'; frame.style.border = '0';\n    frame.setAttribute('allow', 'fullscreen'); frame.title = 'Cabinet Quest';\n    if (container && container.appendChild) container.appendChild(frame);\n\n    // Force participants to play: hide Next until the phase reports complete.\n    // (Comment out the next line if you want a manual Next as a fallback.)\n    try { var nb = document.getElementById('NextButton'); if (nb) nb.style.display = 'none'; } catch (e) {}\n\n    function handler(event) {\n        if (event.origin !== GITHUB_ORIGIN) { return; }\n        var data = event.data;\n        if (!data || data.source !== 'codesbu') { return; }\n\n        if (data.summary && typeof data.summary === 'object') {\n            for (var key in data.summary) {\n                if (Object.prototype.hasOwnProperty.call(data.summary, key)) {\n                    Qualtrics.SurveyEngine.setEmbeddedData(key, data.summary[key]);\n                }\n            }\n        }\n        if (data.sid) { Qualtrics.SurveyEngine.setEmbeddedData('sid', data.sid); }\n\n        // session_complete = this phase is done -> store its log and advance.\n        if (data.type === 'session_complete') {\n            if (data.log) { Qualtrics.SurveyEngine.setEmbeddedData(LOG_FIELD, data.log); }\n            try { var nb2 = document.getElementById('NextButton'); if (nb2) nb2.style.display = ''; } catch (e) {}\n            try { self.clickNextButton(); } catch (e) {}\n        }\n    }\n    window.addEventListener('message', handler, false);\n    this.__cqHandler = handler;\n});\n\nQualtrics.SurveyEngine.addOnUnload(function () {\n    if (this.__cqHandler) { window.removeEventListener('message', this.__cqHandler, false); }\n});"
+      }
+    },
+    {
+      "SurveyID": "SV_CabinetQuestStudy01",
+      "Element": "SQ",
+      "PrimaryAttribute": "QID9",
+      "SecondaryAttribute": "q_s3",
+      "TertiaryAttribute": null,
+      "Payload": {
+        "QuestionText": "How confident were you completing Scenario 3?",
+        "QuestionText_Unsafe": "How confident were you completing Scenario 3?",
+        "DataExportTag": "q_s3",
+        "QuestionType": "MC",
+        "Selector": "SAVR",
+        "SubSelector": "TX",
+        "Configuration": {
+          "QuestionDescriptionOption": "UseText"
+        },
+        "QuestionDescription": "How confident were you completing Scenario 3?",
+        "Choices": {
+          "1": {
+            "Display": "1 – Not at all"
+          },
+          "2": {
+            "Display": "2"
+          },
+          "3": {
+            "Display": "3"
+          },
+          "4": {
+            "Display": "4"
+          },
+          "5": {
+            "Display": "5 – Extremely"
+          }
+        },
+        "ChoiceOrder": [
+          "1",
+          "2",
+          "3",
+          "4",
+          "5"
+        ],
+        "Validation": {
+          "Settings": {
+            "ForceResponse": "OFF",
+            "Type": "None"
+          }
+        },
+        "Language": [],
+        "NextChoiceId": 6,
+        "NextAnswerId": 1,
+        "QuestionID": "QID9",
+        "DataVisibility": {
+          "Private": false,
+          "Hidden": false
+        }
+      }
+    },
+    {
+      "SurveyID": "SV_CabinetQuestStudy01",
+      "Element": "SQ",
+      "PrimaryAttribute": "QID10",
+      "SecondaryAttribute": "post_intervention",
+      "TertiaryAttribute": null,
+      "Payload": {
+        "QuestionText": "<h3>Post-Intervention</h3><p><em>[Replace this block with your post-intervention / usability / debrief items. All gameplay metrics (cq_*) and per-scenario event logs (cq_log_*) are already captured.]</em></p>",
+        "QuestionText_Unsafe": "<h3>Post-Intervention</h3><p><em>[Replace this block with your post-intervention / usability / debrief items. All gameplay metrics (cq_*) and per-scenario event logs (cq_log_*) are already captured.]</em></p>",
+        "DataExportTag": "post_intervention",
+        "QuestionType": "DB",
+        "Selector": "TB",
+        "SubSelector": "",
+        "Configuration": {
+          "QuestionDescriptionOption": "UseText"
+        },
+        "QuestionDescription": "post_intervention",
+        "ChoiceOrder": [],
+        "Validation": {
+          "Settings": {
+            "Type": "None"
+          }
+        },
+        "DataVisibility": {
+          "Private": false,
+          "Hidden": false
+        },
+        "QuestionID": "QID10"
+      }
+    },
+    {
+      "SurveyID": "SV_CabinetQuestStudy01",
+      "Element": "QC",
+      "PrimaryAttribute": "Survey Question Count",
+      "SecondaryAttribute": "10",
+      "TertiaryAttribute": null,
+      "Payload": null
+    }
+  ]
+}

--- a/index.html
+++ b/index.html
@@ -1357,6 +1357,14 @@ const PARENT_ORIGIN=_QP.get('parentOrigin')||null; // optional explicit target o
 const IS_EMBEDDED=(window.parent!==window);
 if(QUALTRICS_SID) S.sid=QUALTRICS_SID;          // stamp the Qualtrics key onto app state + localStorage records
 
+// Directed/longitudinal embedding: run a single phase per survey page.
+//   phase=full (default) -> normal standalone behavior (intro + all scenarios)
+//   phase=tutorial        -> run only the interactive tutorial
+//   phase=scenario&scenario=<id|index> -> run only that one scenario
+const PHASE=_QP.get('phase')||'full';
+const SCEN_PARAM=_QP.get('scenario');
+const DIRECTED=(PHASE==='tutorial'||PHASE==='scenario');
+
 // Integer code legends for compact logging (decodable via these maps, which are
 // also embedded in the log header so it is self-contained).
 const AREA_CODES={}; DATA.carts.forEach((c,i)=>AREA_CODES[c.id]=i);
@@ -2636,7 +2644,9 @@ function submitInventory(){
 
     var fo = '';
     fo += '<button class="bp" style="background:var(--accent-amber);border-color:#c88a18;color:var(--text-dark);flex:1" onclick="closeModal(\'fb-modal\');retryScenario()">Retry</button>';
-    if (S.si < DATA.scenarios.length - 1)
+    if (DIRECTED)
+        fo += '<button class="bp" style="flex:1" onclick="closeModal(\'fb-modal\');finishDirectedScenario()">Continue \u2192</button>';
+    else if (S.si < DATA.scenarios.length - 1)
         fo += '<button class="bp" style="flex:1" onclick="closeModal(\'fb-modal\');continueToNext()">Next Scenario \u2192</button>';
     else
         fo += '<button class="bp" style="flex:1" onclick="closeModal(\'fb-modal\');continueToNext()">Complete \u1F389</button>';
@@ -2916,6 +2926,7 @@ function advanceTutorial(trigger){
 function startInteractiveTutorial(){
     tutorialActive = true;
     tutorialStep = 0;
+    resetMission(); logEv(1,0); // 0 = tutorial
     S.mode = 'training';
     S.scenario = {id:'tutorial',name:'Tutorial',description:'Learn the basics.',essential:['saline-flush'],optional:[]};
     S.inv = [];
@@ -3047,7 +3058,9 @@ function endTutorialWithSuccess(){
     // Show completion message then start training
     document.getElementById('fb-h').textContent = 'Tutorial Complete!';
     document.getElementById('fb-body').innerHTML = '<div style="text-align:center;padding:16px"><div style="font-size:48px;margin-bottom:12px">\uD83C\uDF89</div><p style="font-size:14px;font-weight:600;margin-bottom:6px">Great job!</p><p style="font-size:12px;color:var(--text-mid)">You\'ve learned how to navigate carts, open drawers, select items, return to room view, review collected items, and submit. Now let\'s start the real training!</p></div>';
-    document.getElementById('fb-foot').innerHTML = '<button class="bp" style="flex:1" onclick="closeModal(\'fb-modal\');startTrainingMode()">Start Training \u2192</button>';
+    document.getElementById('fb-foot').innerHTML = DIRECTED
+        ? '<button class="bp" style="flex:1" onclick="closeModal(\'fb-modal\');finishDirectedTutorial(true)">Continue \u2192</button>'
+        : '<button class="bp" style="flex:1" onclick="closeModal(\'fb-modal\');startTrainingMode()">Start Training \u2192</button>';
     openModal('fb-modal'); sfx('success');
 }
 
@@ -3062,6 +3075,7 @@ function endTutorial(){
     if(activeDrawer3D){slideDrawerClosed(activeDrawer3D);activeDrawer3D=null;}
     S.scenario = null; S.inv = []; S.st = null;
     goToDefaultView(true);
+    if(DIRECTED){ finishDirectedTutorial(false); return; }
     startTrainingMode();
 }
 
@@ -3394,13 +3408,67 @@ if('serviceWorker' in navigator){navigator.serviceWorker.register('sw.js').catch
 // ===== PORTRAIT LOCK =====
 try{if(screen.orientation&&screen.orientation.lock)screen.orientation.lock('portrait').catch(function(){});}catch(e){}
 
+// ===== DIRECTED (single-phase) EMBED MODE =====
+// Used when the app is embedded one phase per Qualtrics survey page so that
+// survey questions can be interleaved between scenarios. On completion the
+// phase emits session_complete (which the parent survey treats as its
+// advance signal) with only that phase's fields + its own event log, so the
+// per-scenario cq_mN_* fields never collide across pages (all share one sid).
+function startDirected(){
+    var ov=document.getElementById('intro-overlay'); if(ov){ov.classList.add('hidden');ov.style.opacity='';}
+    document.querySelector('.hdr').style.display='';
+    document.getElementById('cart-labels').style.opacity='';
+    if(PHASE==='tutorial'){
+        goToDefaultView(false);
+        setTimeout(startInteractiveTutorial,400);
+    } else { // scenario
+        var idx=parseInt(SCEN_PARAM,10);
+        var sc=DATA.scenarios.find(function(s){return s.id===SCEN_PARAM;});
+        if(!sc && !isNaN(idx)) sc=DATA.scenarios[idx];
+        if(!sc) sc=DATA.scenarios[0];
+        startDirectedScenario(sc);
+    }
+}
+function startDirectedScenario(sc){
+    S.su=DATA.scenarios.length; // unlocks irrelevant in directed mode
+    selScen(sc, DATA.scenarios.indexOf(sc));
+}
+// Continue button after a directed scenario's feedback: emit + lock + advance.
+function finishDirectedScenario(){
+    logEv(8);
+    var num=S.si+1;
+    var flat=Object.assign({cq_app_version:APP_VERSION,cq_mode:'training'}, S.missionSummaries[num]||{});
+    emitResults('session_complete', flat, buildLog());
+    hideTray(); closeSidePanel();
+    document.querySelector('.app').classList.remove('scenario-active');
+    showDirectedDone('Scenario complete.');
+}
+// Tutorial finished (or skipped) in directed mode.
+function finishDirectedTutorial(completed){
+    logEv(8);
+    var summary={cq_tut_completed:completed?1:0, cq_tut_time:Math.round((Date.now()-SESSION_START_WALL)/1000), cq_app_version:APP_VERSION};
+    emitResults('session_complete', summary, buildLog());
+    hideTray(); closeSidePanel();
+    showDirectedDone('Tutorial complete.');
+}
+function showDirectedDone(msg){
+    var d=document.getElementById('directed-done');
+    if(!d){
+        d=document.createElement('div'); d.id='directed-done';
+        d.style.cssText='position:fixed;inset:0;z-index:99999;display:flex;align-items:center;justify-content:center;background:rgba(18,28,38,.94);color:#fff;text-align:center;padding:24px';
+        document.body.appendChild(d);
+    }
+    d.innerHTML='<div style="max-width:340px"><div style="font-size:52px;margin-bottom:14px">✅</div><p style="font-size:17px;font-weight:700;margin-bottom:8px">'+msg+'</p><p style="font-size:13px;opacity:.85;line-height:1.5">Please continue with the survey. If it does not advance automatically, click the survey’s Next button.</p></div>';
+    d.style.display='flex';
+}
+
 // ===== INIT =====
 function init(){
     load();
     init3D();
     upStats();
-    // Start cinematic intro (replaces old tutorial modal)
-    startCinematicIntro();
+    if(DIRECTED){ startDirected(); }
+    else { startCinematicIntro(); } // normal cinematic intro + full game
 }
 window.onload=init;
 </script>


### PR DESCRIPTION
## Summary
Adds a **directed embed mode** so the game can be split across a longitudinal Qualtrics flow with questions interleaved between phases:

> Consent → **Tutorial** → Qs → **Scenario 1** → Qs → **Scenario 2** → Qs → **Scenario 3** → Qs → Post

All pages share one `sid`, so everything lands in a single response row (panel-linkable, longitudinal).

## App changes (`index.html`)
- New URL params: **`phase`** (`full` | `tutorial` | `scenario`) and **`scenario`** (`s4`/`s2`/`s3` or index). `phase=full` is the default and preserves existing standalone / single-iframe behavior exactly.
- Directed mode skips the cinematic intro + menus and runs exactly one phase:
  - **Scenario page:** auto-starts that scenario; on *Continue* emits `session_complete` carrying **only that mission's `cq_mN_*` fields + that page's event log** — no cross-mission aggregates, so fields never collide across pages.
  - **Tutorial page:** emits `cq_tut_completed` / `cq_tut_time` + the tutorial log; skipping still advances.
  - Feedback footer shows a single **Continue →** in directed mode; a completion overlay prompts the participant to proceed in the survey.
- `session_complete` doubles as the parent survey's **advance signal** (listener calls `clickNextButton()`).

## Qualtrics / docs
- **`cabinet-quest-study.qsf`** — importable 10-block survey implementing the full flow. Each game page injects its iframe with the correct `phase`, writes its log to a dedicated `cq_log_*` field, **hides Next until the phase completes** (so the game can't be skipped), and auto-advances. Consent / post / per-phase question blocks are editable placeholders for IRB items.
- **`QUALTRICS_INTEGRATION.md`** — new §7 (longitudinal flow), `phase`/`scenario` params, `cq_tut_*` / `cq_log_*` fields, per-page embed URLs, and a Stony Brook `parentOrigin` note.

## Testing
- Full inline script passes `node --check`.
- Directed-mode harness confirms: `phase`/`scenario` parse correctly; `s2` → mission index 1 (`cq_m2_*`); scenario pages emit `mission_complete` + `session_complete` with **only** that mission's fields (no `cq_total_score`/`cq_missions_done` collisions); tutorial emits `cq_tut_completed=1` + `cq_tut_time`.
- Study QSF validates: 4 iframe pages with correct phase/log-field/origin-check/auto-advance, 60 embedded-data fields declared, 10 blocks in order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)